### PR TITLE
PA_SPA_1: Fix checkpass function

### DIFF
--- a/PA_SPA_1-Timing_Analysis_with_Power_for_Password_Bypass.ipynb
+++ b/PA_SPA_1-Timing_Analysis_with_Power_for_Password_Bypass.ipynb
@@ -400,11 +400,11 @@
     "def checkpass(trace, i):\n",
     "    if PLATFORM == \"CWNANO\":\n",
     "        #There's a bit of jitter\n",
-    "        return (trace[228 + 11*i] < 3 and trace[227 + 11*i] < 0.3)\n",
+    "        return (trace[228 + 11*i] > 3 and trace[227 + 11*i] > 0.3)\n",
     "    elif PLATFORM == \"CWLITEARM\" or PLATFORM == \"CW308_STM32F3\":\n",
-    "        return trace[229 + 36*i] > -0.2\n",
+    "        return trace[229 + 36*i] < -0.2\n",
     "    elif PLATFORM == \"CW303\" or PLATFORM == \"CWLITEXMEGA\":\n",
-    "        return trace[73 + 40 * i] > -0.3"
+    "        return trace[73 + 40 * i] < -0.3"
    ]
   },
   {


### PR DESCRIPTION
Seems like there is a mixup when it comes to less than and greater than
in the ["Attacking a Single Letter" example](https://github.com/newaetech/chipwhisperer-jupyter/blob/master/PA_SPA_1-Timing_Analysis_with_Power_for_Password_Bypass.ipynb?short_path=f3960fe#L400-L408). For example for
"`CW303`" and "`CWLITEXMEGA`" there is a comparison like this

```python
   return trace[73 + 40 * i] > -0.3
```

Since we are interested in (**negative**) peaks in that case we should use a
less than sign instead of greater than.

After doing the changes in this patch I've been able to successfully run
the example in Jupyter using Chipwhisperer-Lite ("`CW303`", "`CWLITEXMEGA`").

Since I believe it's wrong for "`CWNANO`" as well as for "`CWLITEARM`" and
"`CW308_STM32F3`" I've made similar changes.

Signed-off-by: Joakim Bech <joakim.bech@linaro.org>