### PR TITLE
Correct SS_VER for Fault_1_2

### DIFF
--- a/courses/fault101/Fault 1_2 - Clock Glitching to Bypass Password.ipynb
+++ b/courses/fault101/Fault 1_2 - Clock Glitching to Bypass Password.ipynb
@@ -82,9 +82,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%bash -s \"$PLATFORM\"\n",
+    "%%bash -s \"$PLATFORM\" \"$SS_VER\"\n",
     "cd ../../../hardware/victims/firmware/simpleserial-glitch\n",
-    "make PLATFORM=$1 CRYPTO_TARGET=NONE -j"
+    "make PLATFORM=$1 CRYPTO_TARGET=NONE SS_VER=$2 -j"
    ]
   },
   {
@@ -104,7 +104,7 @@
    "source": [
     "fw_path = \"../../../hardware/victims/firmware/simpleserial-glitch/simpleserial-glitch-{}.hex\".format(PLATFORM)\n",
     "cw.program_target(scope, prog, fw_path)\n",
-    "if SS_VER == 'SS_VER_2_0':\n",
+    "if SS_VER == 'SS_VER_2_1':\n",
     "    target.reset_comms()"
    ]
   },
@@ -146,6 +146,7 @@
    "outputs": [],
    "source": [
     "#Do glitch loop\n",
+    "reboot_flush()",
     "pw = bytearray([0x00]*5)\n",
     "target.simpleserial_write('p', pw)\n",
     "\n",
@@ -173,6 +174,7 @@
    "outputs": [],
    "source": [
     "#Do glitch loop\n",
+    "reboot_flush()",
     "pw = bytearray([0x74, 0x6F, 0x75, 0x63, 0x68]) # correct password ASCII representation\n",
     "target.simpleserial_write('p', pw)\n",
     "\n",


### PR DESCRIPTION
Set all SS_VER to SS_VER_2_1, otherwise `vaild` will always return False.