### PR TITLE
Add missing variable to lab

### DIFF
--- a/courses/fault101/Fault 2_2 - Voltage Glitching to Bypass Password.ipynb
+++ b/courses/fault101/Fault 2_2 - Voltage Glitching to Bypass Password.ipynb
@@ -189,6 +189,8 @@
     "\n",
     "reboot_flush()\n",
     "\n",
+    "successes = 0\n",
+    "\n",
     "for glitch_settings in gc.glitch_values():\n",
     "    scope.glitch.offset = glitch_settings[1]\n",
     "    scope.glitch.width = glitch_settings[0]\n",


### PR DESCRIPTION
successes is not defined which causes the success case to fail and not report.