### PR TITLE
typo in SCA 101, LAB5_1

### DIFF
--- a/courses/sca101/Lab 5_1 - ChipWhisperer CPA Attacks in Practice.ipynb
+++ b/courses/sca101/Lab 5_1 - ChipWhisperer CPA Attacks in Practice.ipynb
@@ -182,7 +182,7 @@
    "source": [
     "import chipwhisperer.analyzer as cwa\n",
     "#pick right leakage model for your attack\n",
-    "leak_model = cwa.leakage_model.sbox_output\n",
+    "leak_model = cwa.leakage_models.sbox_output\n",
     "attack = cwa.cpa(project, leak_model)\n",
     "results = attack.run(cwa.get_jupyter_callback(attack))"
    ]
@@ -203,7 +203,7 @@
     "import chipwhisperer.common.api.lascar as cw_lascar\n",
     "from lascar import *\n",
     "cw_container = cw_lascar.CWContainer(project, project.textins)\n",
-    "cpa_engines = [CpaEngine(\"cpa_%02d\" % i, cw_lascar.sbox_HW_gen(i, range(256)) for i in range(16)]\n",
+    "cpa_engines = [CpaEngine(\"cpa_%02d\" % i, cw_lascar.sbox_HW_gen(i), range(256)) for i in range(16)]\n",
     "session = Session(cw_container, engines=cpa_engines).run(batch_size=50)"
    ]
   },


### PR DESCRIPTION
Fixed a typo in tutorial LAB5_1.

line 185: leakage_model  -->  leakage_models
line 206: cw_lascar.sbox_HW_gen(i, range(256))  -->  cw_lascar.sbox_HW_gen(i), range(256))