### PR TITLE
Fix - generate getsome() using helper function.

### DIFF
--- a/Setup_Scripts/Setup_Ibex.ipynb
+++ b/Setup_Scripts/Setup_Ibex.ipynb
@@ -69,13 +69,15 @@
     "\n",
     "# But let's program the FPGA bitfile:\n",
     "if PLATFORM == 'CW305_IBEX':\n",
-    "    from chipwhisperer.hardware.firmware.cw305 import getsome\n",
+    "    from chipwhisperer.hardware.firmware.open_fw import getsome_generator\n",
+    "    getsome = getsome_generator(\"cw305\")\n",
     "    bsdata = getsome(f\"lowrisc_ibex_demo_system.bit\")\n",
     "    cw305 = cw.target(None, cw.targets.CW305, bsfile=None, force=False)\n",
     "    status = cw305.fpga.FPGAProgram(bsdata, exceptOnDoneFailure=False, prog_speed=10e6)\n",
     "    \n",
     "elif PLATFORM == 'CW312_IBEX':\n",
-    "    from chipwhisperer.hardware.firmware.xc7a35 import getsome\n",
+    "    from chipwhisperer.hardware.firmware.open_fw import getsome_generator\n",
+    "    getsome = getsome_generator(\"xc7a35\")\n",
     "    bsdata = getsome(f\"lowrisc_ibex_demo_system.bit\")\n",
     "    #from chipwhisperer.hardware.naeusb.programmer_targetfpga import CW312T_XC7A35T\n",
     "    fpga = cw.hardware.naeusb.programmer_targetfpga.CW312T_XC7A35T(scope)\n",
@@ -118,7 +120,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
A non-existing getsome() function was imported in the Setup_Ibex.ipynb notebook. It seems getsome should be generated using the getsome_generator function instead. I updated this, and passed in the appropriate platform names so that it finds the corresponding bitstream.