### PR TITLE
[codex] Use ipympl for interactive matplotlib plots

### DIFF
--- a/0 - Introduction to Jupyter Notebooks.ipynb
+++ b/0 - Introduction to Jupyter Notebooks.ipynb
@@ -138,7 +138,7 @@
    "source": [
     "Often it's nice to have an interactive graph. We can do that with a special *magic* at the start of our notebook, which looks like this:\n",
     "\n",
-    "    %matplotlib notebook\n",
+    "    %matplotlib ipympl\n",
     "    import matplotlib.pylab as plt\n",
     "    \n",
     "    plt.plot([1,2,2,4,5], 'r')\n",
@@ -153,7 +153,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib notebook\n",
+    "%matplotlib ipympl\n",
     "import matplotlib.pylab as plt\n",
     "    \n",
     "plt.plot([1,2,2,4,5], 'r')\n",
@@ -177,7 +177,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib notebook\n",
+    "%matplotlib ipympl\n",
     "import matplotlib.pylab as plt\n",
     "fig = plt.figure()"
    ]

--- a/ChipWhisperer Setup Test.ipynb
+++ b/ChipWhisperer Setup Test.ipynb
@@ -70,7 +70,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib notebook\n",
+    "%matplotlib ipympl\n",
     "import matplotlib.pylab as plt\n",
     "plt.plot(range(0, 10))"
    ]

--- a/courses/fault201/Lab 1_2 - 1.5 Round AES Attack.ipynb
+++ b/courses/fault201/Lab 1_2 - 1.5 Round AES Attack.ipynb
@@ -127,7 +127,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib notebook\n",
+    "%matplotlib ipympl\n",
     "import matplotlib.pyplot as plt\n",
     "plt.figure()\n",
     "plt.plot(wave[:2000])\n",
@@ -218,7 +218,7 @@
     "    else:\n",
     "        reboot_flush()\n",
     "        \n",
-    "%matplotlib notebook\n",
+    "%matplotlib ipympl\n",
     "import matplotlib.pyplot as plt\n",
     "plt.figure()\n",
     "plt.plot(wave)\n",
@@ -303,7 +303,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib notebook\n",
+    "%matplotlib ipympl\n",
     "import matplotlib.pyplot as plt\n",
     "plt.figure()\n",
     "plt.plot(wave)\n",

--- a/courses/fault201/Lab 1_3B - DFA Attack on AES.ipynb
+++ b/courses/fault201/Lab 1_3B - DFA Attack on AES.ipynb
@@ -759,7 +759,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib notebook\n",
+    "%matplotlib ipympl\n",
     "gc.results.plot_2d(plotdots={\"column0\":\"+g\", \"column1\":\"pr\", \"column2\":\"bo\", \n",
     "                             \"column3\":\"sk\", \"normal\":None, \"other\":None, \"reset\":None},\n",
     "                   x_index=2, y_index=0)"
@@ -778,7 +778,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib notebook\n",
+    "%matplotlib ipympl\n",
     "gc.results.plot_2d(plotdots={\"column0\":\"^g\", \"column1\":\"vg\", \"column2\":\"<g\", \n",
     "                             \"column3\":\">g\", \"normal\":None, \"other\":\"b.\", \"reset\":\"rx\"},\n",
     "                   x_index=2, y_index=0)"

--- a/courses/faultapp1/LPC1114_Fuse_Bypass.ipynb
+++ b/courses/faultapp1/LPC1114_Fuse_Bypass.ipynb
@@ -244,7 +244,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib notebook\n",
+    "%matplotlib ipympl\n",
     "import matplotlib.pylab as plt\n",
     "\n",
     "\n",
@@ -309,7 +309,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib notebook\n",
+    "%matplotlib ipympl\n",
     "import matplotlib.pylab as plt\n",
     "import numpy as np\n",
     "\n",
@@ -329,7 +329,7 @@
    },
    "outputs": [],
    "source": [
-    "%matplotlib notebook\n",
+    "%matplotlib ipympl\n",
     "import matplotlib.pylab as plt\n",
     "import numpy as np\n",
     "\n",

--- a/courses/sca101/Lab 2_1B - Power Analysis for Password Bypass (MAIN).ipynb
+++ b/courses/sca101/Lab 2_1B - Power Analysis for Password Bypass (MAIN).ipynb
@@ -132,7 +132,7 @@
     "For reference, the output should look something like this:\n",
     "<img src=\"img/spa_password_h_vs_0_overview.png\" alt=\"SPA of Power Analysis\" width=\"450\"/>\n",
     "\n",
-    "If you are using the `%matplotlib notebook` magic, you can zoom in at the start. What you want to notice is there is two code paths taken, depending on a correct or incorrect path. Here for example is a correct & incorrect character processed:\n",
+    "If you are using the `%matplotlib ipympl` magic, you can zoom in at the start. What you want to notice is there is two code paths taken, depending on a correct or incorrect path. Here for example is a correct & incorrect character processed:\n",
     "<img src=\"img/spa_password_h_vs_0_zoomed.png\" alt=\"SPA of Power Analysis\" width=\"450\"/>"
    ]
   },

--- a/courses/sca101/Lab 3_3 - DPA on Firmware Implementation of AES (MAIN).ipynb
+++ b/courses/sca101/Lab 3_3 - DPA on Firmware Implementation of AES (MAIN).ipynb
@@ -667,7 +667,7 @@
     "\n",
     "Using `full_diffs_list[N]` to get your selected subkey, plot the correct key by plotting `full_diffs_list[N][0xCORRECT]` in green as the *last* (so it appears on top). Plot a few other highly ranked guesses before that. In my example, this would look like:\n",
     "\n",
-    "    %matplotlib notebook\n",
+    "    %matplotlib ipympl\n",
     "    import matplotlib.pylab as plt\n",
     "\n",
     "    plt.plot(full_diffs_list[5][0xC5], 'r')\n",

--- a/courses/sca101/Lab 4_2 - CPA on Firmware Implementation of AES (MAIN).ipynb
+++ b/courses/sca101/Lab 4_2 - CPA on Firmware Implementation of AES (MAIN).ipynb
@@ -97,7 +97,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib notebook\n",
+    "%matplotlib ipympl\n",
     "import matplotlib.pylab as plt\n",
     "\n",
     "# ###################\n",

--- a/courses/sca101/Lab 6_4 - Jittery Triggering on UART.ipynb
+++ b/courses/sca101/Lab 6_4 - Jittery Triggering on UART.ipynb
@@ -208,7 +208,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib notebook\n",
+    "%matplotlib ipympl\n",
     "import matplotlib.pylab as plt\n",
     "\n",
     "fig = plt.figure()"
@@ -344,7 +344,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib notebook\n",
+    "%matplotlib ipympl\n",
     "import matplotlib.pylab as plt\n",
     "\n",
     "fig = plt.figure()"
@@ -537,7 +537,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib notebook\n",
+    "%matplotlib ipympl\n",
     "import matplotlib.pylab as plt\n",
     "\n",
     "fig = plt.figure()"

--- a/courses/sca101/SOLN_Lab 2_1B - Power Analysis for Password Bypass.ipynb
+++ b/courses/sca101/SOLN_Lab 2_1B - Power Analysis for Password Bypass.ipynb
@@ -161,7 +161,7 @@
     "For reference, the output should look something like this:\n",
     "<img src=\"img/spa_password_h_vs_0_overview.png\" alt=\"SPA of Power Analysis\" width=\"450\"/>\n",
     "\n",
-    "If you are using the `%matplotlib notebook` magic, you can zoom in at the start. What you want to notice is there is two code paths taken, depending on a correct or incorrect path. Here for example is a correct & incorrect character processed:\n",
+    "If you are using the `%matplotlib ipympl` magic, you can zoom in at the start. What you want to notice is there is two code paths taken, depending on a correct or incorrect path. Here for example is a correct & incorrect character processed:\n",
     "<img src=\"img/spa_password_h_vs_0_zoomed.png\" alt=\"SPA of Power Analysis\" width=\"450\"/>"
    ]
   },

--- a/courses/sca101/SOLN_Lab 3_3 - DPA on Firmware Implementation of AES.ipynb
+++ b/courses/sca101/SOLN_Lab 3_3 - DPA on Firmware Implementation of AES.ipynb
@@ -758,7 +758,7 @@
     "\n",
     "Using `full_diffs_list[N]` to get your selected subkey, plot the correct key by plotting `full_diffs_list[N][0xCORRECT]` in green as the *last* (so it appears on top). Plot a few other highly ranked guesses before that. In my example, this would look like:\n",
     "\n",
-    "    %matplotlib notebook\n",
+    "    %matplotlib ipympl\n",
     "    import matplotlib.pylab as plt\n",
     "\n",
     "    plt.plot(full_diffs_list[5][0xC5], 'r')\n",

--- a/courses/sca101/generators/Lab2_1B - GENERATOR.ipynb
+++ b/courses/sca101/generators/Lab2_1B - GENERATOR.ipynb
@@ -1005,7 +1005,7 @@
     }
    ],
    "source": [
-    "%matplotlib notebook\n",
+    "%matplotlib ipympl\n",
     "import matplotlib.pylab as plt\n",
     "\n",
     "trace_correct = cap_pass_trace(\"h0\\n\")\n",

--- a/courses/sca201/Lab 2_3 - Attacking Across MixColumns.ipynb
+++ b/courses/sca201/Lab 2_3 - Attacking Across MixColumns.ipynb
@@ -232,7 +232,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib notebook\n",
+    "%matplotlib ipympl\n",
     "import matplotlib.pyplot as plt\n",
     "plt.figure()\n",
     "for i in range(5):\n",
@@ -304,7 +304,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib notebook\n",
+    "%matplotlib ipympl\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
     "plt.figure()\n",
@@ -474,7 +474,7 @@
     "campaign = 0\n",
     "n_traces = 10000\n",
     "key_guess = []\n",
-    "%matplotlib notebook\n",
+    "%matplotlib ipympl\n",
     "import matplotlib.pyplot as plt\n",
     "plt.figure()\n",
     "    \n",
@@ -534,7 +534,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib notebook\n",
+    "%matplotlib ipympl\n",
     "import matplotlib.pyplot as plt\n",
     "plt.figure()\n",
     "plt.plot(c[0x16])\n",
@@ -549,7 +549,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib notebook\n",
+    "%matplotlib ipympl\n",
     "import matplotlib.pyplot as plt\n",
     "plt.figure()\n",
     "for i in range(256):\n",

--- a/courses/sca201/Lab 3_1B - Reverse Engineering on the AES256 Bootloader.ipynb
+++ b/courses/sca201/Lab 3_1B - Reverse Engineering on the AES256 Bootloader.ipynb
@@ -675,7 +675,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib notebook\n",
+    "%matplotlib ipympl\n",
     "import matplotlib.pyplot as plt\n",
     "plt.figure()\n",
     "plt.plot(wave)\n",

--- a/courses/sca201/SOLN_Lab 1_1A - Resychronizing Traces with Sum of Absolute Difference.ipynb
+++ b/courses/sca201/SOLN_Lab 1_1A - Resychronizing Traces with Sum of Absolute Difference.ipynb
@@ -241,7 +241,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib notebook\n",
+    "%matplotlib ipympl\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
     "target_offset = calculate_trace_offset(ref_trace, 1700, proj.waves[1], 10)\n",

--- a/courses/sca202/PA_SPA_2-RSA_on_XMEGA_8bit.ipynb
+++ b/courses/sca202/PA_SPA_2-RSA_on_XMEGA_8bit.ipynb
@@ -135,7 +135,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib notebook\n",
+    "%matplotlib ipympl\n",
     "import matplotlib.pylab as plt\n",
     "text = bytearray([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x80, 0x00])\n",
     "def capture_RSA_trace(scope, target, text):\n",
@@ -185,7 +185,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib notebook\n",
+    "%matplotlib ipympl\n",
     "import matplotlib.pylab as plt\n",
     "plt.plot(trace, 'r')"
    ]
@@ -203,7 +203,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib notebook\n",
+    "%matplotlib ipympl\n",
     "import matplotlib.pylab as plt\n",
     "ref_trace = trace[3600:4100]\n",
     "plt.plot(ref_trace, 'b')"
@@ -215,7 +215,7 @@
    "source": [
     "As you slide the \"offset\" along, you'll see the resulting pattern be slid along as well. The SAD is calculated and printed.\n",
     "\n",
-    "**NB**: An artifact of Jupyter is that once you run this cell, the `%matplotlib notebook` magic may no longer work. If you want to get interactive graphs again, you'll need to restart the kernel & not run this cell. Restarting the kernel will require you to capture data again. You can easily do the remained of the tutorial without the interactive graphs (meaning it's not needed to restart the kernel after this cell)."
+    "**NB**: An artifact of Jupyter is that once you run this cell, the `%matplotlib ipympl` magic may no longer work. If you want to get interactive graphs again, you'll need to restart the kernel & not run this cell. Restarting the kernel will require you to capture data again. You can easily do the remained of the tutorial without the interactive graphs (meaning it's not needed to restart the kernel after this cell)."
    ]
   },
   {

--- a/demos/Using Segmented Memory for Hardware AES (STM32F4).ipynb
+++ b/demos/Using Segmented Memory for Hardware AES (STM32F4).ipynb
@@ -196,7 +196,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib notebook\n",
+    "%matplotlib ipympl\n",
     "import matplotlib.pylab as plt\n",
     "\n",
     "#For reference - you can see all the traces here as one (how it's read from teh buffer)\n",
@@ -269,7 +269,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib notebook\n",
+    "%matplotlib ipympl\n",
     "import matplotlib.pylab as plt\n",
     "\n",
     "#For reference - you can see all the traces here as one (how it's read from teh buffer)\n",

--- a/demos/experiments/Live Plotting Glitch.ipynb
+++ b/demos/experiments/Live Plotting Glitch.ipynb
@@ -179,7 +179,7 @@
     "# GlitchController will be part of ChipWhisperer core - just run this block\n",
     "# for now.\n",
     "\n",
-    "%matplotlib notebook\n",
+    "%matplotlib ipympl\n",
     "import matplotlib.pylab as plt\n",
     "\n",
     "import ipywidgets as widgets          \n",
@@ -413,7 +413,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib notebook\n",
+    "%matplotlib ipympl\n",
     "import matplotlib.pylab as plt\n",
     "\n",
     "# plot_2d is part of CW core, but has some bugs with huge data (like generated here) where you don't\n",

--- a/demos/experiments/MixColumn Attack.ipynb
+++ b/demos/experiments/MixColumn Attack.ipynb
@@ -137,7 +137,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib notebook\n",
+    "%matplotlib ipympl\n",
     "import matplotlib.pyplot as plt\n",
     "plt.figure()\n",
     "for i in range(5):\n",
@@ -193,7 +193,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib notebook\n",
+    "%matplotlib ipympl\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
     "plt.figure()\n",
@@ -365,7 +365,7 @@
     "campaign = 0\n",
     "n_traces = 10000\n",
     "key_guess = []\n",
-    "%matplotlib notebook\n",
+    "%matplotlib ipympl\n",
     "import matplotlib.pyplot as plt\n",
     "plt.figure()\n",
     "    \n",
@@ -425,7 +425,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib notebook\n",
+    "%matplotlib ipympl\n",
     "import matplotlib.pyplot as plt\n",
     "plt.figure()\n",
     "plt.plot(c[0x16])\n",
@@ -440,7 +440,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib notebook\n",
+    "%matplotlib ipympl\n",
     "import matplotlib.pyplot as plt\n",
     "plt.figure()\n",
     "for i in range(256):\n",

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ nbparameterise
 pandas
 holoviews
 matplotlib
+ipympl
 PyYAML
 tqdm
 PyCryptoDome

--- a/tests/tutorials.py
+++ b/tests/tutorials.py
@@ -172,9 +172,9 @@ def execute_notebook(nb_path, serial_number=None, baud=None, hw_location=None, t
                 r'(cw|chipwhisperer)(\.target\()(.*,)(.*)(\))': r"\1\2\3\4, hw_location={}\5".format(target_hw_location)
             })
 
-        # %matplotlib notebook won't show up in blank plots
+        # %matplotlib ipympl won't show up in blank plots
         # so replace with %matplotlib inline for now
-        replacements.update({'%matplotlib notebook' : '%matplotlib inline'})
+        replacements.update({'%matplotlib ipympl' : '%matplotlib inline'})
 
         # complete all regex subtitutions
         if replacements:


### PR DESCRIPTION
## Summary

- add `ipympl` to notebook requirements
- switch interactive Matplotlib notebook magic from `%matplotlib notebook` to `%matplotlib ipympl`
- update the tutorial execution helper to substitute `%matplotlib ipympl` with `%matplotlib inline` during tests

## Why

Modern Jupyter Notebook/JupyterLab no longer provides the old frontend `IPython` JavaScript global expected by Matplotlib's legacy `notebook` backend. In Notebook 7, cells using `%matplotlib notebook` can fail with:

```text
Javascript Error: IPython is not defined
```

`ipympl` is the supported interactive Matplotlib widget backend for current Jupyter environments, so this preserves interactive plotting instead of falling back to static inline output.

Fixes #72.

## Validation

- confirmed no `%matplotlib notebook` references remain
- validated all 19 modified notebooks parse as JSON
- ran `python -m py_compile tests/tutorials.py`
- ran `git diff --check`
- verified `ipympl` resolves in the ChipWhisperer Python environment